### PR TITLE
Fix email-modal double-send and state leak across re-opens

### DIFF
--- a/projects/normalize/src/app/map/email-modal/email-modal.component.ts
+++ b/projects/normalize/src/app/map/email-modal/email-modal.component.ts
@@ -1,7 +1,6 @@
 import { ElementRef, OnDestroy, ViewChild } from '@angular/core';
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import { debounceTime, first } from 'rxjs/operators';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { first } from 'rxjs/operators';
 import { ApiService } from '../../api.service';
 import { ImageFetcherService } from '../../image-fetcher.service';
 import { StateService } from '../../state.service';
@@ -12,7 +11,7 @@ import { StateService } from '../../state.service';
     styleUrls: ['./email-modal.component.less'],
     standalone: false
 })
-export class EmailModalComponent implements OnInit, OnDestroy, OnChanges {
+export class EmailModalComponent implements OnDestroy, OnChanges {
 
   @Input() open = true;
   @Output() closed = new EventEmitter<string>();
@@ -29,34 +28,35 @@ export class EmailModalComponent implements OnInit, OnDestroy, OnChanges {
 
   private autoDeleteTimerHandle: ReturnType<typeof setTimeout> | null = null;
   private countdownIntervalHandle: ReturnType<typeof setInterval> | null = null;
+  private emailIdleTimerHandle: ReturnType<typeof setTimeout> | null = null;
+  private hasSubmitted = false;
   private readonly AUTO_DELETE_DELAY_MS = 25000;
   private readonly COUNTDOWN_SECONDS = 10;
-
-  triggerEmailTimeout = new BehaviorSubject<boolean>(null);
+  private readonly EMAIL_IDLE_TIMEOUT_MS = 30000;
 
   constructor(private api: ApiService, private state: StateService, public imageFetcher: ImageFetcherService) { }
-
-  ngOnInit(): void {
-    this.ensureConfirmationImage();
-    this.startAutoDeleteTimer();
-    this.triggerEmailTimeout.pipe(
-      debounceTime(30000),
-      first()
-    ).subscribe(() => {
-      if (this.phase === 1) {
-        this.submitEmail();
-      }
-    });
-  }
 
   ngOnDestroy(): void {
     this.clearTimers();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.open?.currentValue === true) {
-      this.ensureConfirmationImage();
+    if (!changes.open) {
+      return;
     }
+    if (changes.open.currentValue === true) {
+      this.resetForOpen();
+    } else {
+      this.clearTimers();
+    }
+  }
+
+  private resetForOpen(): void {
+    this.phase = 0;
+    this._emailAddress = null;
+    this.hasSubmitted = false;
+    this.ensureConfirmationImage();
+    this.startAutoDeleteTimer();
   }
 
   private startAutoDeleteTimer(): void {
@@ -87,11 +87,30 @@ export class EmailModalComponent implements OnInit, OnDestroy, OnChanges {
       clearInterval(this.countdownIntervalHandle);
       this.countdownIntervalHandle = null;
     }
+    this.clearEmailIdleTimer();
+  }
+
+  private startEmailIdleTimer(): void {
+    this.clearEmailIdleTimer();
+    this.emailIdleTimerHandle = setTimeout(() => {
+      this.emailIdleTimerHandle = null;
+      if (this.phase === 1 && !this.hasSubmitted) {
+        this.submitEmail();
+      }
+    }, this.EMAIL_IDLE_TIMEOUT_MS);
+  }
+
+  private clearEmailIdleTimer(): void {
+    if (this.emailIdleTimerHandle !== null) {
+      clearTimeout(this.emailIdleTimerHandle);
+      this.emailIdleTimerHandle = null;
+    }
   }
 
   addToMap(): void {
     this.clearTimers();
     this.phase = 1;
+    this.startEmailIdleTimer();
   }
 
   backToConfirmation(): void {
@@ -163,12 +182,22 @@ export class EmailModalComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   submitEmail(): void {
+    if (this.hasSubmitted) {
+      return;
+    }
+    this.hasSubmitted = true;
+    this.clearTimers();
     this.state.pushRequest(this.api.sendEmail(this.hasEmail ? this.emailAddress : null));
     this.state.setAskedForEmail();
     this.closed.emit('added');
   }
 
   noThanks(): void {
+    if (this.hasSubmitted) {
+      return;
+    }
+    this.hasSubmitted = true;
+    this.clearTimers();
     this.state.pushRequest(this.api.sendEmail(null));
     this.state.setAskedForEmail();
     this.closed.emit('added');
@@ -182,7 +211,9 @@ export class EmailModalComponent implements OnInit, OnDestroy, OnChanges {
 
   set emailAddress(value: string) {
     this._emailAddress = value;
-    this.triggerEmailTimeout.next(true);
+    if (this.phase === 1) {
+      this.startEmailIdleTimer();
+    }
   }
 
   get emailAddress() {


### PR DESCRIPTION
## Summary

Fixes two bugs introduced in the post-selfie email-modal redesign (#13, #17):

- **Double-send of `/sendEmail`** — the 30s "idle-form auto-submit" was a `BehaviorSubject` + `debounceTime(30000)` + `first()` subscribed in `ngOnInit`. The BehaviorSubject's initial `null` emission started the clock at component construction, and `first()` meant the subscription terminated after one fire. After a real submit, the still-pending debounce window (last reset by a keystroke) would fire ~30s later; because the parent only toggles `[open]` and never destroys the component, `phase === 1` was still true and `submitEmail()` ran a second time. If the 30s elapsed while still in phase 0, the only emission was consumed and the safety net was permanently dead.
- **State leak across re-opens** — `ngOnInit` ran only on first construction and `ngOnChanges` only refetched the image. After the flow completed, `phase` and `_emailAddress` persisted, so the next open could land mid-flow with a stale email pre-filled.

## Fixes

- Replace the rxjs idle pipe with a plain `setTimeout` (`emailIdleTimerHandle`) matching the existing `autoDeleteTimer` style: started on phase-1 entry in `addToMap()`, reset by the `emailAddress` setter, torn down by `clearTimers()` on submit/back/retake/delete/close/destroy.
- Move all open-lifecycle work into `ngOnChanges`: on `open=true` call `resetForOpen()` (phase=0, clear email, clear `hasSubmitted`, refetch image, restart auto-delete timer); on `open=false` call `clearTimers()`. Drop the now-redundant `ngOnInit` and `OnInit` interface.
- Defense-in-depth: `hasSubmitted` guard short-circuits `submitEmail()` and `noThanks()` on any second invocation, covering double-clicks between the inline send arrow and the modal's send button, plus any stray timer that escapes teardown.

A separate, unrelated bug (`isLoadingFallbackImage` not reset in the `error` callback of `ensureConfirmationImage`) was identified during review but left for a follow-up.

## Test plan

- [ ] Take a selfie, click "Add to map", type an email, click send — verify exactly one `POST /sendEmail` in the network tab.
- [ ] Same as above but click the modal's "send" button instead of the inline arrow — still one request.
- [ ] Take a selfie, click "Add to map", type, click send, then take another selfie — verify modal re-opens at phase 0 with empty email input, not at phase 1 with stale value.
- [ ] Take a selfie and wait without interacting — auto-delete countdown still fires at 25s + 10s.
- [ ] Take a selfie, click "Add to map", do not type — auto-submit (with `null` email) fires 30s after entering the email form, not 30s after component construction.
- [ ] Take a selfie, click "Add to map", click the back arrow — returns to phase 0 with auto-delete timer restarted; no stray auto-submit afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)