### PR TITLE
Fix share-link overlay path for images not in the TSNE grid

### DIFF
--- a/projects/normalize/src/app/map/map.component.ts
+++ b/projects/normalize/src/app/map/map.component.ts
@@ -231,17 +231,8 @@ export class MapComponent implements OnInit, AfterViewInit {
           expectedId = parseInt(sharedId);
           items.push(
             this.api.getImage(expectedId).pipe(
-              map((item: any) => {
-                const existsInGrid = this.configuration?.grid?.some((gridItem: GridItem) => gridItem.item.id === expectedId);
-                if (!existsInGrid) {
-                  this.blockItemById(expectedId);
-                  expectedId = null;
-                  return null;
-                }
-                return item as ImageItem;
-              }),
+              map((item: any) => item as ImageItem),
               catchError(() => {
-                this.blockItemById(expectedId);
                 expectedId = null;
                 return from([null]);
               })


### PR DESCRIPTION
## Summary

When opening the site with `?id=N`, the intended behaviour is:
- if `N` exists in the TSNE grid, zoom to its position;
- otherwise, fetch it, place it next to its nearest neighbour by descriptor distance, and overlay it there.

The second path has been broken since #13.

## Root cause

PR #13 (post-selfie redesign) added an `existsInGrid` guard to the share-link branch in `map.component.ts` that bailed out exactly when the overlay path should run: a non-grid id was routed to `blockItemById` (the moderation/mask path) and the stream emitted `null`, so `TSNEOverlay.addImageLayer` never saw the item.

The own-item branch right above (`map.component.ts:214-227`) does not have this guard, which is why "focus on my own selfie" kept working through the overlay path while shared links did not.

`TSNEOverlay.addImageLayer` already handles both branches:
- if the id is in the grid → returns the existing `GridItem`;
- otherwise → finds the nearest neighbour by `euclideanDistance` over descriptors, picks an empty cell via `findEmpty`, and attaches an `L.ImageOverlay`.

The caller was short-circuiting before that code ever ran.

## Fix

Drop the `existsInGrid` check and let the item flow into `addImageLayer`. Keep the `catchError` so a fetch failure doesn't break other items in the merge stream, but remove the `blockItemById` call from it — fetching a shared id is not a moderation event.

## Test plan

- [ ] Open the site with `?id=<id of an image in the static grid>` — verify it zooms to that grid position.
- [ ] Open the site with `?id=<id of a fetchable image NOT in the static grid>` — verify the image is fetched, placed next to its nearest neighbour, overlaid on the map, and zoomed/focused.
- [ ] Open the site with `?id=<non-existent id>` — verify the app loads cleanly (no crash, no focus).
- [ ] Open the site without `?id` — verify normal behaviour (own selfie focus if present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)