### PR TITLE
Remove dead blocking/masking subsystem from map component

### DIFF
--- a/projects/normalize/src/app/map/map.component.ts
+++ b/projects/normalize/src/app/map/map.component.ts
@@ -60,15 +60,12 @@ export class MapComponent implements OnInit, AfterViewInit {
   redirectModalOpen = false;
   emailModalOpen = false;
   deleteModalOpen = false;
-  blockedGridItems: GridItem[] = [];
-  blockedMasks: L.Rectangle[] = [];
 
   private readonly transitionEase = 0.12;
   private readonly zoomOutDurationSec = 1.35;
   private readonly zoomInDurationSec = 1.65;
   private readonly drawerMoveDurationSec = 1.1;
   private readonly mapBackgroundColor = '#EAE7DF';
-  private readonly blockedMaskColor = '#2D2C29';
 
   @ViewChild(OutputMapComponent) mapElement: OutputMapComponent;
   @ViewChild(EmailModalComponent) emailModal: EmailModalComponent;
@@ -148,7 +145,6 @@ export class MapComponent implements OnInit, AfterViewInit {
         // Create map
         this.map = this.mapElement.getMap(this.configuration);
         this.feature = 'faces';
-        this.applyBlockedMasks();
         // Map events
         this.map.on('zoomend', (ev) => { return this.onZoomChange(); });
         this.map.on('moveend', (ev) => { return this.onBoundsChange(); });
@@ -425,42 +421,6 @@ export class MapComponent implements OnInit, AfterViewInit {
     if (this.map) {
       this.flyToSmooth(this.map.getCenter(), this.maxZoom - 5, this.zoomOutDurationSec).subscribe();
     }
-  }
-
-  private blockItemById(itemID: number): void {
-    if (!Number.isFinite(itemID) || !this.configuration?.grid) {
-      return;
-    }
-    const idx = this.configuration.grid.findIndex((item) => item.item.id === itemID);
-    if (idx !== -1) {
-      const [blocked] = this.configuration.grid.splice(idx, 1);
-      this.blockedGridItems.push(blocked);
-      this.grid.next(this.configuration.grid);
-      this.addBlockedMask(blocked);
-    }
-  }
-
-  private applyBlockedMasks(): void {
-    if (!this.map) {
-      return;
-    }
-    this.blockedMasks.forEach((mask) => mask.remove());
-    this.blockedMasks = [];
-    this.blockedGridItems.forEach((item) => {
-      this.addBlockedMask(item);
-    });
-  }
-
-  private addBlockedMask(item: GridItem): void {
-    if (!this.map || !item?.pos) {
-      return;
-    }
-    const pos = item.pos;
-    const mask = L.rectangle(
-      [[-pos.y - 1, pos.x], [-pos.y, pos.x + 1]] as L.LatLngBoundsExpression,
-      { color: 'transparent', weight: 0, fillColor: this.blockedMaskColor, fillOpacity: 1, interactive: false }
-    ).addTo(this.map);
-    this.blockedMasks.push(mask);
   }
 
   focusOnSelf() {

--- a/projects/normalize/src/app/map/map.component.ts
+++ b/projects/normalize/src/app/map/map.component.ts
@@ -231,17 +231,8 @@ export class MapComponent implements OnInit, AfterViewInit {
           expectedId = parseInt(sharedId);
           items.push(
             this.api.getImage(expectedId).pipe(
-              map((item: any) => {
-                const existsInGrid = this.configuration?.grid?.some((gridItem: GridItem) => gridItem.item.id === expectedId);
-                if (!existsInGrid) {
-                  this.blockItemById(expectedId);
-                  expectedId = null;
-                  return null;
-                }
-                return item as ImageItem;
-              }),
+              map((item: any) => item as ImageItem),
               catchError(() => {
-                this.blockItemById(expectedId);
                 expectedId = null;
                 return from([null]);
               })


### PR DESCRIPTION
## Summary

Removes the orphaned moderation/masking code in `MapComponent` whose last callers disappeared with #20.

**Depends on #20** — that PR removes the only two call sites of `blockItemById` (in the share-link branch). Once #20 lands and this branch is rebased onto master, the diff here is purely a deletion.

## What's dead

| Symbol | Why dead |
|---|---|
| `blockedGridItems`, `blockedMasks` | populated only by `blockItemById` |
| `blockedMaskColor` | read only by `addBlockedMask` |
| `blockItemById` | zero callers post-#20 |
| `applyBlockedMasks` | iterates an always-empty list; the only caller is the map-init pipeline |
| `addBlockedMask` | reached only via the two methods above |

The path that *would* have flagged blocked items (an `isBlockedItem` check on fetched images) was already removed in #18, so the trigger has been gone for a while — only the rendering/state machinery was left.

## Why not keep it for "future moderation"

If moderation/masking is reintroduced later it should be designed around an actual signal — a server flag on grid items, an admin gesture, etc. — not the half-built shape this code preserved. Easier to write fresh than to revive code whose original triggers are gone.

## Test plan

- [ ] App builds and runs cleanly with no `blocked*` references remaining.
- [ ] Map loads normally; no visible regressions on focus/zoom/grid interaction.
- [ ] Share link with id flow (covered by #20) still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)