### PR TITLE
Fix report-card retake to delete the old item and clear local state

### DIFF
--- a/projects/normalize/src/app/map/map.component.html
+++ b/projects/normalize/src/app/map/map.component.html
@@ -13,7 +13,7 @@
     <app-about-card [showStart]='!hasSelfie' (start)='start()'></app-about-card>
   }
   @if (focusedItem) {
-    <app-report-card [item]='focusedItem.item' (delete)='delete()' (start)='start(true)'></app-report-card>
+    <app-report-card [item]='focusedItem.item' (delete)='delete()' (start)='retake()'></app-report-card>
   }
 </app-drawer>
 @if (!hasSelfie) {

--- a/projects/normalize/src/app/map/map.component.ts
+++ b/projects/normalize/src/app/map/map.component.ts
@@ -351,6 +351,14 @@ export class MapComponent implements OnInit, AfterViewInit {
     this.drawerOpen = false
   }
 
+  retake() {
+    if (this.state.getOwnItemID()) {
+      this.state.pushRequest(this.api.deleteOwnItem());
+    }
+    this.state.fullClear();
+    this.start(true);
+  }
+
   delete() {
     this.drawerOpen = false
     this.deleteModalOpen = true


### PR DESCRIPTION
## Summary

The "retake" button on the map's report card never deleted the previous server-side item. Each time a returning user retook their photo from the map, a fresh item was created server-side and the old one was orphaned — the `magic` needed to delete it had been overwritten on the client.

The post-selfie email-modal retake (`email-modal.component.ts:146-151`) already does this correctly. This PR mirrors that flow for the report-card path.

## Root cause

- `report-card.component.html:83` emits `start`.
- `map.component.html:16` binds it to `start(true)`.
- `MapComponent.start(skipConsent=true)` only routes to `/selfie` (or opens the desktop redirect modal). No `deleteOwnItem`, no `fullClear`.
- `selfie.component.ts:309-327` then calls `api.createNew(event)`. `event.id` and `event.magic` are set but `api.createNew` (`api.service.ts:18-21`) doesn't forward them — the endpoint is `new` and treats every call as a fresh submission. The server returns a new id/magic; `setOwnInfo` (`state.service.ts:94-115`) overwrites local state. The old item is orphaned, unreachable from the client.

This shape has existed since `14e7a90` ("Implement delete face") — it's a long-standing oversight, not a recent regression.

## Fix

Add a dedicated `retake()` method on `MapComponent`:

```ts
retake() {
  if (this.state.getOwnItemID()) {
    this.state.pushRequest(this.api.deleteOwnItem());
  }
  this.state.fullClear();
  this.start(true);
}
```

`api.deleteOwnItem` reads id/magic synchronously (`api.service.ts:78-90`), so the closure captures them before `fullClear` wipes local state. Then it delegates to `start(true)` so the existing mobile/desktop navigation logic is unchanged.

Rebind `(start)` on the report card from `start(true)` to `retake()`. The `start` event name on `ReportCardComponent` stays — only the consumer's binding changes.

`start(true)` was previously called from exactly one place (this report-card binding), so adding the cleanup *inside* `start` would have been safe today, but `start` is conceptually "begin onboarding" and would silently delete identity if anyone passed `skipConsent` in the future. A dedicated `retake()` keeps the intent explicit.

## Test plan

- [ ] Take a selfie on mobile → land on map with own face.
- [ ] Tap own face → report card opens. Note current `itemID`/`magic` in localStorage.
- [ ] Tap "retake": verify a delete-item POST fires with the *old* `id`+`magic` in the query params.
- [ ] Verify localStorage `OWN_ID_KEY`, `OWN_IMAGE_KEY`, `OWN_MAGIC_KEY`, `PLAYED_KEY`, `ASKED_FOR_EMAIL_KEY` are removed.
- [ ] App routes to `/selfie`. Take a new selfie. Confirm a fresh `id`/`magic` lands in localStorage.
- [ ] Repeat — no duplicate items accumulate.
- [ ] Desktop sanity check: tapping report-card "retake" on a desktop viewport still opens `redirectModalOpen` (the "go to mobile" message), and localStorage is cleared before that modal opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)