### PR TITLE
Skip t-SNE recomputation when input descriptors are unchanged

### DIFF
--- a/backend/lib/calc_tsne.py
+++ b/backend/lib/calc_tsne.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import hashlib
 import json
 import math
 from io import BytesIO
@@ -250,62 +251,116 @@ IMAGES = [
     ("faces", (300, 300), (1200, 0)),
 ]
 
+_INPUT_HASH_KEY = "tsne-input.sha256"
+_INPUT_HASH_URL = f"https://normalizing-us-files.fra1.digitaloceanspaces.com/{_INPUT_HASH_KEY}"
 
-def main():
-    perplexity = 50
-    tsne_iter = 5000
+
+def compute_input_hash(ids: list[dict], activations: list) -> str:
+    """SHA-256 over the (id, descriptor) pairs that feed t-SNE.
+
+    Stable across runs: the load_activations query orders by id DESC so input
+    order is deterministic given the same row set. Vote counts and other
+    metadata are deliberately excluded — they don't affect the layout, so
+    changing them alone shouldn't trigger a recompute.
+    """
+    h = hashlib.sha256()
+    for item, descriptor in zip(ids, activations, strict=True):
+        h.update(str(item["id"]).encode("utf-8"))
+        h.update(b":")
+        h.update(json.dumps(descriptor, separators=(",", ":")).encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def fetch_previous_input_hash() -> str | None:
+    """Read the input hash persisted by the previous run, or None if unavailable."""
+    try:
+        resp = requests.get(_INPUT_HASH_URL, timeout=10)
+    except requests.RequestException:
+        return None
+    if resp.status_code != 200:
+        return None
+    return resp.text.strip() or None
+
+
+def upload_input_hash(input_hash: str) -> bool:
+    buff = BytesIO(input_hash.encode("utf-8"))
+    return upload_fileobj_s3(buff, _INPUT_HASH_KEY, "text/plain")
+
+
+def main(
+    to_plot: int = 450,
+    out_dim: int = 30,
+    tsne_iter: int = 5000,
+    perplexity: int = 50,
+    side: int = 256,
+    skip_upload: bool = False,
+):
     ids, activations = load_activations()
-    out_dim = 30
-    to_plot = 450
-    side = 256
     ids = ids[:to_plot]
-    loaders = []
+    activations = activations[:to_plot]
+
+    input_hash = compute_input_hash(ids, activations)
+    if not skip_upload and fetch_previous_input_hash() == input_hash:
+        print(f"t-SNE inputs unchanged (hash {input_hash[:12]}); skipping recomputation.")
+        return
+
+    all_loaders = []
     for _filename, img_size, img_location in IMAGES:
         w, h = img_size
         dim = max(w, h)
         size = side / 2
-        loaders.append(
+        all_loaders.append(
             ImageLoader(
-                [item["image"] for item in ids[0:to_plot]],
+                [item["image"] for item in ids],
                 [int(size * w / dim), int(size * h / dim), img_location, img_size],
             )
         )
-    loaders[0].start()
 
     try:
-        current_config = requests.get(
-            "https://normalizing-us-files.fra1.digitaloceanspaces.com/tsne.json",
-            timeout=10,
-        ).json()
-        current_set = current_config.get("set", 0)
-    except (requests.RequestException, ValueError):
-        current_set = 0
-    current_set = (current_set + 1) % 10
+        loaders = list(all_loaders)
+        loaders[0].start()
 
-    print("Generating 2D representation.")
-    X_2d = generate_tsne(activations, to_plot, perplexity, tsne_iter)
-    print(f"Generating image grid ({out_dim}x{out_dim}, {len(ids)} images)")
-    grid = calc_tsne_grid(X_2d, out_dim)
+        try:
+            current_config = requests.get(
+                "https://normalizing-us-files.fra1.digitaloceanspaces.com/tsne.json",
+                timeout=10,
+            ).json()
+            current_set = current_config.get("set", 0)
+        except (requests.RequestException, ValueError):
+            current_set = 0
+        current_set = (current_set + 1) % 10
 
-    info: dict = {}
-    for filename, img_size, _img_location in IMAGES:
-        w, h = img_size
-        dim = max(w, h)
-        size = side / 2
-        size_tuple = (int(size * w / dim), int(size * h / dim))
-        offset = (int((side - size_tuple[0]) / 2), int((side - size_tuple[1]) / 2))
-        image, info = create_tsne_image(
-            grid, ids, out_dim, to_plot, (side, side), offset, size_tuple, loaders.pop(0)
-        )
-        info["set"] = current_set
-        if len(loaders) > 0:
-            loaders[0].start()
-        create_tiles(filename, image, out_dim, (side, side), info, current_set)
+        print("Generating 2D representation.")
+        X_2d = generate_tsne(activations, to_plot, perplexity, tsne_iter)
+        print(f"Generating image grid ({out_dim}x{out_dim}, {len(ids)} images)")
+        grid = calc_tsne_grid(X_2d, out_dim)
 
-    json_buff = BytesIO()
-    json_buff.write(json.dumps(info).encode("utf8"))
-    json_buff.seek(0)
-    upload_fileobj_s3(json_buff, "tsne.json", "application/json")
+        info: dict = {}
+        for filename, img_size, _img_location in IMAGES:
+            w, h = img_size
+            dim = max(w, h)
+            size = side / 2
+            size_tuple = (int(size * w / dim), int(size * h / dim))
+            offset = (int((side - size_tuple[0]) / 2), int((side - size_tuple[1]) / 2))
+            image, info = create_tsne_image(
+                grid, ids, out_dim, to_plot, (side, side), offset, size_tuple, loaders.pop(0)
+            )
+            info["set"] = current_set
+            if len(loaders) > 0:
+                loaders[0].start()
+            if not skip_upload:
+                create_tiles(filename, image, out_dim, (side, side), info, current_set)
+
+        if not skip_upload:
+            json_buff = BytesIO()
+            json_buff.write(json.dumps(info).encode("utf8"))
+            json_buff.seek(0)
+            upload_fileobj_s3(json_buff, "tsne.json", "application/json")
+            upload_input_hash(input_hash)
+    finally:
+        for loader in all_loaders:
+            loader.fini()
 
 
 def calc_tsne_handler(event, context):

--- a/backend/tests/test_calc_tsne.py
+++ b/backend/tests/test_calc_tsne.py
@@ -14,9 +14,12 @@ from PIL import Image
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
+import lib.calc_tsne as calc_tsne_module
 from lib.calc_tsne import (
     array_to_img,
     calc_tsne_grid,
+    compute_input_hash,
+    fetch_previous_input_hash,
     generate_tsne,
     img_to_array,
     process_item,
@@ -148,3 +151,138 @@ def test_process_item_truncates_and_rounds():
     out = process_item(item)
     assert out["descriptor"] == [0.123, 0.678, -0.432]
     assert out["landmarks"] == [{"x": 10, "y": 20}, {"x": 30, "y": 40}]
+
+
+# ---------- compute_input_hash ----------
+
+def test_compute_input_hash_deterministic():
+    ids = [{"id": 1, "image": "a"}, {"id": 2, "image": "b"}]
+    activations = [[0.1, 0.2], [0.3, 0.4]]
+    assert compute_input_hash(ids, activations) == compute_input_hash(ids, activations)
+
+
+def test_compute_input_hash_changes_with_id():
+    descriptors = [[0.1, 0.2]]
+    assert compute_input_hash([{"id": 1}], descriptors) != compute_input_hash([{"id": 2}], descriptors)
+
+
+def test_compute_input_hash_changes_with_descriptor():
+    ids = [{"id": 1}]
+    assert compute_input_hash(ids, [[0.1, 0.2]]) != compute_input_hash(ids, [[0.1, 0.3]])
+
+
+def test_compute_input_hash_changes_with_order():
+    """load_activations orders by id DESC, so a different order represents a different DB state."""
+    ids_a = [{"id": 1}, {"id": 2}]
+    ids_b = [{"id": 2}, {"id": 1}]
+    descriptors_a = [[0.1], [0.2]]
+    descriptors_b = [[0.2], [0.1]]
+    assert compute_input_hash(ids_a, descriptors_a) != compute_input_hash(ids_b, descriptors_b)
+
+
+# ---------- fetch_previous_input_hash ----------
+
+def test_fetch_previous_input_hash_returns_text(monkeypatch):
+    class _Resp:
+        status_code = 200
+        text = "deadbeef\n"
+
+    monkeypatch.setattr(calc_tsne_module.requests, "get", lambda *a, **kw: _Resp())
+    assert fetch_previous_input_hash() == "deadbeef"
+
+
+def test_fetch_previous_input_hash_returns_none_on_404(monkeypatch):
+    class _Resp:
+        status_code = 404
+        text = "not found"
+
+    monkeypatch.setattr(calc_tsne_module.requests, "get", lambda *a, **kw: _Resp())
+    assert fetch_previous_input_hash() is None
+
+
+def test_fetch_previous_input_hash_returns_none_on_network_error(monkeypatch):
+    def _raise(*a, **kw):
+        raise calc_tsne_module.requests.ConnectionError("boom")
+
+    monkeypatch.setattr(calc_tsne_module.requests, "get", _raise)
+    assert fetch_previous_input_hash() is None
+
+
+def test_fetch_previous_input_hash_returns_none_on_empty_body(monkeypatch):
+    class _Resp:
+        status_code = 200
+        text = "   \n"
+
+    monkeypatch.setattr(calc_tsne_module.requests, "get", lambda *a, **kw: _Resp())
+    assert fetch_previous_input_hash() is None
+
+
+# ---------- main() skip path ----------
+
+def test_main_skips_when_input_hash_matches(monkeypatch, mock_s3_upload):
+    """When the previous hash matches the current input, main() returns without
+    running t-SNE, fetching tsne.json, or uploading anything."""
+    fake_ids = [{"id": 1, "image": "img1"}, {"id": 2, "image": "img2"}]
+    fake_activations = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    expected = compute_input_hash(fake_ids, fake_activations)
+
+    monkeypatch.setattr(calc_tsne_module, "load_activations", lambda: (fake_ids, fake_activations))
+    monkeypatch.setattr(calc_tsne_module, "fetch_previous_input_hash", lambda: expected)
+
+    def _fail_generate(*a, **kw):
+        raise AssertionError("generate_tsne must not be called when hash matches")
+    monkeypatch.setattr(calc_tsne_module, "generate_tsne", _fail_generate)
+
+    def _fail_get(*a, **kw):
+        raise AssertionError("requests.get must not be called when hash matches")
+    monkeypatch.setattr(calc_tsne_module.requests, "get", _fail_get)
+
+    calc_tsne_module.main(to_plot=2)
+
+    assert mock_s3_upload == []
+
+
+def test_main_finalizes_image_loaders_on_error(monkeypatch, mock_s3_upload):
+    """If the pipeline raises after ImageLoader.start(), all loaders' executors
+    must still be shut down — otherwise their threads leak."""
+    fake_ids = [{"id": 1, "image": "img1"}, {"id": 2, "image": "img2"}]
+    fake_activations = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    monkeypatch.setattr(calc_tsne_module, "load_activations", lambda: (fake_ids, fake_activations))
+    monkeypatch.setattr(calc_tsne_module, "fetch_previous_input_hash", lambda: None)
+
+    fini_calls: list[int] = []
+    start_calls: list[int] = []
+    instances: list[object] = []
+
+    class _FakeImageLoader:
+        def __init__(self, images, args):
+            self.images = images
+            self.id = len(instances)
+            instances.append(self)
+
+        def start(self):
+            start_calls.append(self.id)
+
+        def fini(self):
+            fini_calls.append(self.id)
+
+    monkeypatch.setattr(calc_tsne_module, "ImageLoader", _FakeImageLoader)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("simulated failure mid-pipeline")
+    monkeypatch.setattr(calc_tsne_module, "generate_tsne", _boom)
+
+    class _Resp:
+        status_code = 200
+        @staticmethod
+        def json():
+            return {"set": 0}
+    monkeypatch.setattr(calc_tsne_module.requests, "get", lambda *a, **kw: _Resp())
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        calc_tsne_module.main(to_plot=2)
+
+    # Every created loader must have been finalized.
+    assert sorted(fini_calls) == [i.id for i in instances]
+    assert mock_s3_upload == []

--- a/documentation/DEVOPS.md
+++ b/documentation/DEVOPS.md
@@ -25,6 +25,8 @@ Handlers are deployed as Google Cloud Functions. Each exported function in `back
 | `delete-item` | `delete_item_handler` | HTTP POST |
 | `calc_tsne` | `calc_tsne_handler` | Event-triggered (Cloud Tasks / Pub/Sub) |
 
+`calc_tsne` short-circuits when the descriptor set is unchanged. It hashes the `(id, descriptor)` pairs of the rows it would feed into t-SNE and compares against `tsne-input.sha256` in the public DO Spaces bucket. If they match, the run logs a "skipping recomputation" line and exits without running t-SNE, regenerating tiles, or re-uploading `tsne.json`. To force a full recompute, delete `tsne-input.sha256` from the bucket.
+
 ### Runtime
 
 - Python 3.12.


### PR DESCRIPTION
## Summary

The `calc_tsne` cloud function previously rebuilt the entire t-SNE layout on every invocation, even when the descriptor set hadn't changed. With ~450 descriptors and 5000 iterations the run takes 5–15 minutes plus extensive tile regeneration; running it on a no-op is pure waste of compute and DO Spaces egress.

This PR adds an input-hash skip and tightens an unrelated resource leak in the same module.

## What's new

### Hash-based skip

- `compute_input_hash()` hashes the `(id, descriptor)` pairs in the order they would feed t-SNE. The `load_activations` query is `ORDER BY id DESC`, so order is deterministic given the row set.
- `fetch_previous_input_hash()` / `upload_input_hash()` persist the hash next to `tsne.json` in DO Spaces as `tsne-input.sha256`.
- `main()` compares the two and short-circuits if they match, logging a "skipping recomputation" line.

Vote counts and other per-item metadata are **deliberately excluded** from the hash — they don't affect layout, so changing only metadata shouldn't trigger a recompute. Forced full recompute is one S3 delete of `tsne-input.sha256` away, documented in DEVOPS.md.

### Resource cleanup

`ImageLoader.executor` (a 32-thread `ThreadPoolExecutor`) was only finalised inside `create_tsne_image`'s success path. If `generate_tsne` or the preceding `requests.get` raised, the started thread pool kept running until its tasks naturally completed — leaking threads across what should be a clean function exit.

Wrap the post-construction body of `main()` in `try/finally` and call `fini()` on every constructed loader unconditionally. `fini()` is idempotent (no-op when `self.executor is None`), so the existing call inside `create_tsne_image` is harmless overlap.

### main() parameterisation

`scripts/run_calc_tsne.py` was calling `main()` with six kwargs that `main()` didn't accept (pre-existing bug). Adding the params (`to_plot`, `out_dim`, `tsne_iter`, `perplexity`, `side`, `skip_upload`) unblocks the runner without changing the cloud-function entry point — `calc_tsne_handler` still calls `main()` with no args, so production behaviour is unchanged. `skip_upload` short-circuits the hash check, the `tsne.json` upload, the hash upload, and `create_tiles` (which only does uploads), so dev runs no longer touch production.

## Tests

10 new tests in `tests/test_calc_tsne.py`:

- **compute_input_hash** — deterministic; sensitive to id, descriptor, and order changes.
- **fetch_previous_input_hash** — returns text on 200; returns None on 404, network error, or empty body.
- **main() skip path** — when the previous hash matches, generate_tsne isn't called, requests.get isn't called, no S3 uploads happen.
- **main() resource cleanup** — when generate_tsne raises mid-run, every constructed ImageLoader is finalised.

## Test plan

- [ ] First production run after merge: should compute t-SNE as usual and write `tsne-input.sha256`.
- [ ] Second run with no new selfies: should log "t-SNE inputs unchanged ..." and exit in seconds. No `tsne.json` re-upload.
- [ ] After a new selfie is added: hash differs → full recompute, fresh `tsne.json`, fresh hash.
- [ ] Forced recompute: delete `tsne-input.sha256` from DO Spaces, run `calc_tsne` → full recompute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)