### PR TITLE
Set Cache-Control: no-cache on tsne.json so installations see updates promptly

### DIFF
--- a/backend/lib/calc_tsne.py
+++ b/backend/lib/calc_tsne.py
@@ -364,7 +364,12 @@ def main(
             json_buff = BytesIO()
             json_buff.write(json.dumps(info).encode("utf8"))
             json_buff.seek(0)
-            upload_fileobj_s3(json_buff, "tsne.json", "application/json")
+            upload_fileobj_s3(
+                json_buff,
+                "tsne.json",
+                "application/json",
+                cache_control="no-cache",
+            )
             upload_input_hash(input_hash)
     finally:
         for loader in all_loaders:

--- a/backend/lib/net.py
+++ b/backend/lib/net.py
@@ -24,10 +24,19 @@ def get_client():
     )
 
 
-def upload_fileobj_s3(buff: BytesIO, filename: str, content_type: str) -> bool:
+def upload_fileobj_s3(
+    buff: BytesIO,
+    filename: str,
+    content_type: str,
+    cache_control: str | None = None,
+) -> bool:
     global _uploaded
     bucket = os.environ["BUCKET_NAME"]
     client = get_client()
+
+    extra_args: dict[str, str] = {"ACL": "public-read", "ContentType": content_type}
+    if cache_control:
+        extra_args["CacheControl"] = cache_control
 
     success = False
     for _ in range(3):
@@ -36,7 +45,7 @@ def upload_fileobj_s3(buff: BytesIO, filename: str, content_type: str) -> bool:
             buff,
             bucket,
             filename,
-            ExtraArgs={"ACL": "public-read", "ContentType": content_type},
+            ExtraArgs=extra_args,
         )
         head = client.head_object(Bucket=bucket, Key=filename)
         success = bool(head["ContentLength"])

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -179,9 +179,14 @@ def mock_s3_upload(monkeypatch):
     """Replace lib.net.upload_fileobj_s3 with a recorder. Returns the call log."""
     calls: list[dict[str, Any]] = []
 
-    def _fake_upload(buff, filename, content_type):
+    def _fake_upload(buff, filename, content_type, cache_control=None):
         data = buff.getvalue() if hasattr(buff, "getvalue") else None
-        calls.append({"filename": filename, "content_type": content_type, "bytes": len(data) if data else None})
+        calls.append({
+            "filename": filename,
+            "content_type": content_type,
+            "cache_control": cache_control,
+            "bytes": len(data) if data else None,
+        })
         return True
 
     import lib.net as net_module

--- a/backend/tests/test_calc_tsne.py
+++ b/backend/tests/test_calc_tsne.py
@@ -286,3 +286,44 @@ def test_main_finalizes_image_loaders_on_error(monkeypatch, mock_s3_upload):
     # Every created loader must have been finalized.
     assert sorted(fini_calls) == [i.id for i in instances]
     assert mock_s3_upload == []
+
+
+def test_main_uploads_tsne_json_with_cache_control(monkeypatch, mock_s3_upload):
+    """tsne.json should be uploaded with a Cache-Control header so client browsers
+    don't cache it indefinitely under the no-cache-headers heuristic."""
+    fake_ids = [{"id": 1, "image": "img1"}, {"id": 2, "image": "img2"}]
+    fake_activations = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+    monkeypatch.setattr(calc_tsne_module, "load_activations", lambda: (fake_ids, fake_activations))
+    monkeypatch.setattr(calc_tsne_module, "fetch_previous_input_hash", lambda: None)
+
+    class _FakeImageLoader:
+        def __init__(self, *a, **kw):
+            pass
+        def start(self):
+            pass
+        def fini(self):
+            pass
+
+    monkeypatch.setattr(calc_tsne_module, "ImageLoader", _FakeImageLoader)
+    monkeypatch.setattr(calc_tsne_module, "generate_tsne", lambda *a, **kw: np.zeros((2, 2)))
+    monkeypatch.setattr(calc_tsne_module, "calc_tsne_grid", lambda *a, **kw: np.zeros((2, 2)))
+    monkeypatch.setattr(
+        calc_tsne_module,
+        "create_tsne_image",
+        lambda *a, **kw: (Image.new("RGBA", (8, 8)), {"dim": 2, "grid": []}),
+    )
+    monkeypatch.setattr(calc_tsne_module, "create_tiles", lambda *a, **kw: None)
+
+    class _Resp:
+        status_code = 200
+        @staticmethod
+        def json():
+            return {"set": 0}
+    monkeypatch.setattr(calc_tsne_module.requests, "get", lambda *a, **kw: _Resp())
+
+    calc_tsne_module.main(to_plot=2)
+
+    tsne_json_uploads = [c for c in mock_s3_upload if c["filename"] == "tsne.json"]
+    assert len(tsne_json_uploads) == 1
+    assert tsne_json_uploads[0]["cache_control"] == "no-cache"

--- a/backend/tests/test_net.py
+++ b/backend/tests/test_net.py
@@ -49,3 +49,36 @@ def test_upload_fileobj_s3_missing_bucket_raises(monkeypatch):
     # Bucket is never created — upload_fileobj will raise.
     with pytest.raises(Exception):  # noqa: B017 - boto3 raises ClientError subclass
         net.upload_fileobj_s3(BytesIO(b"data"), "path/file.txt", "text/plain")
+
+
+@mock_aws
+def test_upload_fileobj_s3_sets_cache_control(monkeypatch):
+    net.get_client.cache_clear()
+    monkeypatch.setattr(net, "get_client", lambda: boto3.client("s3", region_name="us-east-1"))
+
+    client = net.get_client()
+    client.create_bucket(Bucket="test-bucket")
+
+    net.upload_fileobj_s3(
+        BytesIO(b"data"),
+        "tsne.json",
+        "application/json",
+        cache_control="no-cache",
+    )
+
+    head = client.head_object(Bucket="test-bucket", Key="tsne.json")
+    assert head["CacheControl"] == "no-cache"
+
+
+@mock_aws
+def test_upload_fileobj_s3_omits_cache_control_when_unset(monkeypatch):
+    net.get_client.cache_clear()
+    monkeypatch.setattr(net, "get_client", lambda: boto3.client("s3", region_name="us-east-1"))
+
+    client = net.get_client()
+    client.create_bucket(Bucket="test-bucket")
+
+    net.upload_fileobj_s3(BytesIO(b"data"), "tiles/x.png", "image/png")
+
+    head = client.head_object(Bucket="test-bucket", Key="tiles/x.png")
+    assert "CacheControl" not in head


### PR DESCRIPTION
## Summary

`tsne.json` was being served with **no `Cache-Control` header at all**. Browsers apply RFC 7234 §4.2.2 heuristic caching in that case — `freshness ≈ (now - Last-Modified) / 10` — so a long-stable file can be cached for hours or days.

This is bad for the installation displays. `InstallationBase.ts:49` polls `getMapConfiguration()` every 10 seconds specifically to detect `set` rotation (i.e. "the t-SNE was recomputed"). With heuristic caching they could miss layout changes for the entire freshness window.

The map component (`map.component.ts:79`) only fetches once per `ngOnInit`, so the impact there is minor — but it benefits from explicit cache semantics too.

## Fix

Add an optional `cache_control` kwarg to `upload_fileobj_s3` (default `None`, preserving existing behaviour for tiles/photos/etc.) and pass `"no-cache"` from the `tsne.json` upload site.

`no-cache` semantics: browser may store the response but **must revalidate** before each use. DO Spaces returns `304 Not Modified` when the ETag matches, so the 1.3MB body only crosses the wire when the layout actually changed. Installations now detect recomputes within their 10s polling cadence; the steady-state network cost is just the 304 headers (~hundreds of bytes per poll).

Tiles are intentionally unaffected: each t-SNE recompute rotates `current_set` (mod 10) so tile URLs are content-addressed already; long-lived caching there is fine.

## Tests

- `upload_fileobj_s3` sets `CacheControl` on the object when provided.
- `upload_fileobj_s3` leaves `CacheControl` absent when not provided (regression guard for tiles/photos).
- `main()` upload of `tsne.json` includes `cache_control="no-cache"`.

The `mock_s3_upload` fixture in `conftest.py` was extended to accept the new kwarg; the call log now includes a `cache_control` field, but no existing assertion broke (existing tests only check `filename` / `bytes`).

## Test plan

- [ ] `curl -I https://normalizing-us-files.fra1.digitaloceanspaces.com/tsne.json` after a successful run shows `Cache-Control: no-cache`.
- [ ] On an installation kiosk, after a t-SNE recompute, the layout updates within ~10s (next poll).
- [ ] Other uploads (tiles, photos, hash file) still show no `Cache-Control` (verify with another `curl -I` on a tile URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)