### PR TITLE
Fix test_main_finalizes_image_loaders_on_error: model fini() idempotence

### DIFF
--- a/backend/tests/test_calc_tsne.py
+++ b/backend/tests/test_calc_tsne.py
@@ -256,15 +256,23 @@ def test_main_finalizes_image_loaders_on_error(monkeypatch, mock_s3_upload):
     instances: list[object] = []
 
     class _FakeImageLoader:
+        """Mirrors the real ImageLoader's idempotent fini() so duplicate calls
+        (e.g. an explicit pre-tsne sync fini + the outer try/finally) don't
+        inflate the call log."""
+
         def __init__(self, images, args):
             self.images = images
             self.id = len(instances)
+            self.finalized = False
             instances.append(self)
 
         def start(self):
             start_calls.append(self.id)
 
         def fini(self):
+            if self.finalized:
+                return
+            self.finalized = True
             fini_calls.append(self.id)
 
     monkeypatch.setattr(calc_tsne_module, "ImageLoader", _FakeImageLoader)


### PR DESCRIPTION
## Summary

Master CI has been red since `22815ef` ("sync image fetches with tsne calculation"). That commit added an explicit `loaders[0].fini()` right after `start()` so the t-SNE pass blocks until image fetches finish (sensible — avoids fetch threads competing with t-SNE for memory).

With that change, when the pipeline raises mid-run, `fini()` ends up called twice on the same loader: once explicitly, once again in the outer `try/finally`. The real `ImageLoader.fini()` is idempotent (checks `if self.executor is not None` and short-circuits on the second call), so production is fine. The test's `_FakeImageLoader.fini()` was not — it appended to `fini_calls` every time, so `assert sorted(fini_calls) == [i.id for i in instances]` failed with `[0, 0] == [0]`.

Mirror the real `ImageLoader`'s idempotence in the fake. The test still verifies the leak guard (every constructed loader is finalised); it just no longer counts redundant calls as separate finalisations.

## Test plan

- [x] `pytest tests/test_calc_tsne.py::test_main_finalizes_image_loaders_on_error` passes locally.
- [ ] CI green on master after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)